### PR TITLE
Made protobuf linking dynamic instead of static

### DIFF
--- a/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libprotobuf:
-- '3.19'
+- '3.20'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libprotobuf:
+- '3.19'
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/migrations/libprotobuf320.yaml
+++ b/.ci_support/migrations/libprotobuf320.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libprotobuf:
+- '3.20'
+migrator_ts: 1648312994.8337886

--- a/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.19python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.19python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp4.0.1numpy1.21python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.19python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.19python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp5.0.0numpy1.21python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.19python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.19python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp6.0.1numpy1.21python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.19python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.19python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
+libprotobuf:
+- '3.19'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_arrow_cpp7.0.0numpy1.21python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 libprotobuf:
-- '3.19'
+- '3.20'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/recipe/0001-make-protobuf-linkable.patch
+++ b/recipe/0001-make-protobuf-linkable.patch
@@ -141,7 +141,7 @@ diff --git a/tools/pythonpkg/setup.py b/tools/pythonpkg/setup.py
 index 872ac2acd..f69cabd2c 100755
 --- a/tools/pythonpkg/setup.py
 +++ b/tools/pythonpkg/setup.py
-@@ -91,6 +91,12 @@ if platform.system() == 'Windows':
+@@ -91,6 +91,11 @@ if platform.system() == 'Windows':
  if 'BUILD_HTTPFS' in os.environ:
      libraries += ['crypto', 'ssl']
      extensions += ['httpfs']
@@ -150,7 +150,6 @@ index 872ac2acd..f69cabd2c 100755
 +        libraries += ['libprotoc', 'libprotobuf', 'libprotobuf-lite']
 +    else:
 +        libraries += ['protoc', 'protobuf', 'protobuf-lite']
-+    libraries += ['upb', 'address_sorting',]
  
  for ext in extensions:
      toolchain_args.extend(['-DBUILD_{}_EXTENSION'.format(ext.upper())])

--- a/recipe/0001-make-protobuf-linkable.patch
+++ b/recipe/0001-make-protobuf-linkable.patch
@@ -1,0 +1,159 @@
+From c75e65c37339ea6ee2d0d6d94a73f1134b03f104 Mon Sep 17 00:00:00 2001
+From: Marius van Niekerk <marius.v.niekerk@gmail.com>
+Date: Fri, 17 Jun 2022 15:49:23 -0400
+Subject: [PATCH] make protobuf linkable
+
+---
+ extension/substrait/substrait_config.py | 106 +++++++++++++-----------
+ tools/pythonpkg/setup.py                |   6 ++
+ 2 files changed, 63 insertions(+), 49 deletions(-)
+
+diff --git a/extension/substrait/substrait_config.py b/extension/substrait/substrait_config.py
+index 03b2daf66..1b437347b 100644
+--- a/extension/substrait/substrait_config.py
++++ b/extension/substrait/substrait_config.py
+@@ -1,5 +1,7 @@
+ import os
+ 
++USE_SYSTEM_PROTOBUF = os.environ.get("USE_SYSTEM_PROTOBUF", "false").lower() == "true"
++
+ # list all include directories
+ include_directories = [
+     os.path.sep.join(x.split("/"))
+@@ -7,7 +9,7 @@ include_directories = [
+         "extension/substrait/include/",
+         "third_party/",
+         "third_party/substrait/",
+-        "third_party/google/"
++        *([] if USE_SYSTEM_PROTOBUF else ["third_party/google/"]),
+     ]
+ ]
+ # source files
+@@ -27,53 +29,59 @@ source_files = [
+         "third_party/substrait/substrait/type_expressions.pb.cc",
+         "third_party/substrait/substrait/extensions/extensions.pb.cc",
+         # Protobuf common
+-        "third_party/google/protobuf/any.cc",
+-        "third_party/google/protobuf/any.pb.cc",
+-        "third_party/google/protobuf/any_lite.cc",
+-        "third_party/google/protobuf/arena.cc",
+-        "third_party/google/protobuf/arenastring.cc",
+-        "third_party/google/protobuf/descriptor.cc",
+-        "third_party/google/protobuf/descriptor.pb.cc",
+-        "third_party/google/protobuf/descriptor_database.cc",
+-        "third_party/google/protobuf/dynamic_message.cc",
+-        "third_party/google/protobuf/extension_set.cc",
+-        "third_party/google/protobuf/extension_set_heavy.cc",
+-        "third_party/google/protobuf/generated_enum_util.cc",
+-        "third_party/google/protobuf/generated_message_bases.cc",
+-        "third_party/google/protobuf/generated_message_reflection.cc",
+-        "third_party/google/protobuf/generated_message_table_driven.cc",
+-        "third_party/google/protobuf/generated_message_table_driven_lite.cc",
+-        "third_party/google/protobuf/generated_message_util.cc",
+-        "third_party/google/protobuf/implicit_weak_message.cc",
+-        "third_party/google/protobuf/inlined_string_field.cc",
+-        "third_party/google/protobuf/map.cc",
+-        "third_party/google/protobuf/map_field.cc",
+-        "third_party/google/protobuf/message.cc",
+-        "third_party/google/protobuf/message_lite.cc",
+-        "third_party/google/protobuf/parse_context.cc",
+-        "third_party/google/protobuf/reflection_ops.cc",
+-        "third_party/google/protobuf/repeated_field.cc",
+-        "third_party/google/protobuf/repeated_ptr_field.cc",
+-        "third_party/google/protobuf/text_format.cc",
+-        "third_party/google/protobuf/unknown_field_set.cc",
+-        "third_party/google/protobuf/wire_format.cc",
+-        "third_party/google/protobuf/wire_format_lite.cc",
+-        # Protobuf io
+-        "third_party/google/protobuf/io/coded_stream.cc",
+-        "third_party/google/protobuf/io/io_win32.cc",
+-        "third_party/google/protobuf/io/strtod.cc",
+-        "third_party/google/protobuf/io/tokenizer.cc",
+-        "third_party/google/protobuf/io/zero_copy_stream.cc",
+-        "third_party/google/protobuf/io/zero_copy_stream_impl.cc",
+-        "third_party/google/protobuf/io/zero_copy_stream_impl_lite.cc",
+-        # Protobuf stubs
+-        "third_party/google/protobuf/stubs/common.cc",
+-        "third_party/google/protobuf/stubs/int128.cc",
+-        "third_party/google/protobuf/stubs/status.cc",
+-        "third_party/google/protobuf/stubs/stringpiece.cc",
+-        "third_party/google/protobuf/stubs/stringprintf.cc",
+-        "third_party/google/protobuf/stubs/structurally_valid.cc",
+-        "third_party/google/protobuf/stubs/strutil.cc",
+-        "third_party/google/protobuf/stubs/substitute.cc",
++        *(
++            []
++            if USE_SYSTEM_PROTOBUF
++            else [
++                "third_party/google/protobuf/any.cc",
++                "third_party/google/protobuf/any.pb.cc",
++                "third_party/google/protobuf/any_lite.cc",
++                "third_party/google/protobuf/arena.cc",
++                "third_party/google/protobuf/arenastring.cc",
++                "third_party/google/protobuf/descriptor.cc",
++                "third_party/google/protobuf/descriptor.pb.cc",
++                "third_party/google/protobuf/descriptor_database.cc",
++                "third_party/google/protobuf/dynamic_message.cc",
++                "third_party/google/protobuf/extension_set.cc",
++                "third_party/google/protobuf/extension_set_heavy.cc",
++                "third_party/google/protobuf/generated_enum_util.cc",
++                "third_party/google/protobuf/generated_message_bases.cc",
++                "third_party/google/protobuf/generated_message_reflection.cc",
++                "third_party/google/protobuf/generated_message_table_driven.cc",
++                "third_party/google/protobuf/generated_message_table_driven_lite.cc",
++                "third_party/google/protobuf/generated_message_util.cc",
++                "third_party/google/protobuf/implicit_weak_message.cc",
++                "third_party/google/protobuf/inlined_string_field.cc",
++                "third_party/google/protobuf/map.cc",
++                "third_party/google/protobuf/map_field.cc",
++                "third_party/google/protobuf/message.cc",
++                "third_party/google/protobuf/message_lite.cc",
++                "third_party/google/protobuf/parse_context.cc",
++                "third_party/google/protobuf/reflection_ops.cc",
++                "third_party/google/protobuf/repeated_field.cc",
++                "third_party/google/protobuf/repeated_ptr_field.cc",
++                "third_party/google/protobuf/text_format.cc",
++                "third_party/google/protobuf/unknown_field_set.cc",
++                "third_party/google/protobuf/wire_format.cc",
++                "third_party/google/protobuf/wire_format_lite.cc",
++                # Protobuf io
++                "third_party/google/protobuf/io/coded_stream.cc",
++                "third_party/google/protobuf/io/io_win32.cc",
++                "third_party/google/protobuf/io/strtod.cc",
++                "third_party/google/protobuf/io/tokenizer.cc",
++                "third_party/google/protobuf/io/zero_copy_stream.cc",
++                "third_party/google/protobuf/io/zero_copy_stream_impl.cc",
++                "third_party/google/protobuf/io/zero_copy_stream_impl_lite.cc",
++                # Protobuf stubs
++                "third_party/google/protobuf/stubs/common.cc",
++                "third_party/google/protobuf/stubs/int128.cc",
++                "third_party/google/protobuf/stubs/status.cc",
++                "third_party/google/protobuf/stubs/stringpiece.cc",
++                "third_party/google/protobuf/stubs/stringprintf.cc",
++                "third_party/google/protobuf/stubs/structurally_valid.cc",
++                "third_party/google/protobuf/stubs/strutil.cc",
++                "third_party/google/protobuf/stubs/substitute.cc",
++            ]
++        ),
+     ]
+ ]
+diff --git a/tools/pythonpkg/setup.py b/tools/pythonpkg/setup.py
+index 872ac2acd..f69cabd2c 100755
+--- a/tools/pythonpkg/setup.py
++++ b/tools/pythonpkg/setup.py
+@@ -91,6 +91,12 @@ if platform.system() == 'Windows':
+ if 'BUILD_HTTPFS' in os.environ:
+     libraries += ['crypto', 'ssl']
+     extensions += ['httpfs']
++if 'USE_SYSTEM_PROTOBUF' in os.environ:
++    if platform.system() == 'Windows':
++        libraries += ['libprotoc', 'libprotobuf', 'libprotobuf-lite']
++    else:
++        libraries += ['protoc', 'protobuf', 'protobuf-lite']
++    libraries += ['upb', 'address_sorting',]
+ 
+ for ext in extensions:
+     toolchain_args.extend(['-DBUILD_{}_EXTENSION'.format(ext.upper())])
+-- 
+2.35.3
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,14 @@ build:
   number: 0
   skip: true  # [win]
   script: 
+  # install buf
+  - set -e
+  - set -x
+  - env | sort
+  - export GOBIN="${BUILD_PREFIX}/bin"
+  - export GO111MODULE=on
+  - go install github.com/bufbuild/buf/cmd/buf@v1.5.0
+  - which buf
   # regenerate substrait to match the linked protobuf version
   - python scripts/update_substrait.py
   - rm -rf third_party/google/protobuf
@@ -36,6 +44,7 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - arrow-cpp                              # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
+    - go-nocgo
     - cmake
     - ninja
     - make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
   number: 0
   skip: true  # [win]
   script: 
+  # regenerate substrait to match the linked protobuf version
+  - python scripts/update_substrait.py
   - rm -rf third_party/google/protobuf
   - export USE_SYSTEM_PROTOBUF=true
   - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,16 @@ source:
   sha256: 74863d60977fcb7768c300a0f10a90fbbd3087e310edd42b8e1b1dc5513835dd
   patches:
     # - 487.patch
+    - 0001-make-protobuf-linkable.patch
 
 build:
   number: 0
   skip: true  # [win]
-  script: cd tools/pythonpkg && SETUPTOOLS_SCM_PRETEND_VERSION={{ version }} $PREFIX/bin/python setup.py install
+  script: 
+  - rm -rf third_party/google/protobuf
+  - export USE_SYSTEM_PROTOBUF=true
+  - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
+  - cd tools/pythonpkg && $PREFIX/bin/python setup.py install
   ignore_run_exports:
     - arrow-cpp
 
@@ -25,6 +30,7 @@ requirements:
     - numpy                                  # [build_platform != target_platform]
     - pybind11                               # [build_platform != target_platform]
     - python                                 # [build_platform != target_platform]
+    - libprotobuf                            # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - arrow-cpp                              # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
@@ -42,6 +48,7 @@ requirements:
     - pandas
     - arrow-cpp
     - pyarrow
+    - libprotobuf
   run:
     - python
     - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
This allows duckdb to be installed in the same conda environment as other
libraries that make use of protobuf and used in the same application.  

This will soon make it possible to use `python-duckdb` and `grpcio` in the same python application

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
