### PR TITLE
fix: add patch to short-circuit hash and version in setup.py

### DIFF
--- a/recipe/0002-short-circuit-hash-and-version-discovery.patch
+++ b/recipe/0002-short-circuit-hash-and-version-discovery.patch
@@ -1,0 +1,49 @@
+From 757dab9bfffada4547bf5d1e3053c0164fbd91dd Mon Sep 17 00:00:00 2001
+From: Gil Forsyth <gil@forsyth.dev>
+Date: Thu, 25 Aug 2022 17:02:02 -0400
+Subject: [PATCH] [PATCH] short-circuit hash and version discovery
+
+---
+ scripts/package_build.py | 14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/scripts/package_build.py b/scripts/package_build.py
+index 6b050c1b4..d37dca1dc 100644
+--- a/scripts/package_build.py
++++ b/scripts/package_build.py
+@@ -106,15 +106,16 @@ def get_relative_path(source_dir, target_file):
+     return target_file
+ 
+ def git_commit_hash():
++    if 'SETUPTOOLS_SCM_PRETEND_HASH' in os.environ:
++        return os.environ['SETUPTOOLS_SCM_PRETEND_HASH']
+     try:
+         return subprocess.check_output(['git','log','-1','--format=%h']).strip().decode('utf8')
+     except:
+-        if 'SETUPTOOLS_SCM_PRETEND_HASH' in os.environ:
+-            return os.environ['SETUPTOOLS_SCM_PRETEND_HASH']
+-        else:
+-            return "deadbeeff"
++        return "deadbeeff"
+ 
+ def git_dev_version():
++    if 'SETUPTOOLS_SCM_PRETEND_VERSION' in os.environ:
++        return os.environ['SETUPTOOLS_SCM_PRETEND_VERSION']
+     try:
+         version = subprocess.check_output(['git','describe','--tags','--abbrev=0']).strip().decode('utf8')
+         long_version = subprocess.check_output(['git','describe','--tags','--long']).strip().decode('utf8')
+@@ -128,10 +129,7 @@ def git_dev_version():
+             version_splits[2] = str(int(version_splits[2]) + 1)
+             return '.'.join(version_splits) + "-dev" + dev_version
+     except:
+-        if 'SETUPTOOLS_SCM_PRETEND_VERSION' in os.environ:
+-            return os.environ['SETUPTOOLS_SCM_PRETEND_VERSION']
+-        else:
+-            return "0.0.0"
++        return "0.0.0"
+ 
+ def include_package(pkg_name, pkg_dir, include_files, include_list, source_list):
+     import amalgamation
+-- 
+2.37.2
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,16 +10,15 @@ source:
   sha256: 52dc309da50ea06d02d4d8364a8e1f9fb8da2f1c30fdd65eff119b81ee434bd4
   patches:
     - 0001-fix-parsing-of-stdout-for-mypy-stubs-test.patch
+    - 0002-short-circuit-hash-and-version-discovery.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win or aarch64]
   script:
   # install buf
     - set -e
     - set -x
-  # nuke local `.git` so we can override the SHA bundled as the version
-    - rm -rf .git
     - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   # this needs to match the upstream release commit SHA for extension lookup to work
     - export SETUPTOOLS_SCM_PRETEND_HASH="da9ee490d"


### PR DESCRIPTION
Adding this because the removal of the `.git` repo for some reason isn't
allowing our overrides to show up in the published package.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
