### PR TITLE
fix: update "PRETEND_HASH" for new preview release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dhirschfeld @mariusvniekerk @xhochy
+* @dhirschfeld @gforsyth @mariusvniekerk @xhochy

--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ Feedstock Maintainers
 =====================
 
 * [@dhirschfeld](https://github.com/dhirschfeld/)
+* [@gforsyth](https://github.com/gforsyth/)
 * [@mariusvniekerk](https://github.com/mariusvniekerk/)
 * [@xhochy](https://github.com/xhochy/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   patches:
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script:
   # install buf
@@ -19,7 +19,7 @@ build:
     - set -x
     - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   # this needs to match the upstream release commit SHA for extension lookup to work
-    - export SETUPTOOLS_SCM_PRETEND_HASH="da9ee490d"
+    - export SETUPTOOLS_SCM_PRETEND_HASH="109f932"
     - cd tools/pythonpkg && $PREFIX/bin/python setup.py install
   ignore_run_exports:
     - arrow-cpp


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Still need to update this short hash to point at the new upstream commit hash so that extension resolution works.  I'll take a crack later at automating this.